### PR TITLE
Use DefaultHasher in place of the deprecated SipHasher

### DIFF
--- a/src/key.rs
+++ b/src/key.rs
@@ -673,11 +673,12 @@ mod test {
 
     #[test]
     fn pubkey_hash() {
-        use std::hash::{Hash, SipHasher, Hasher};
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
         use std::collections::HashSet;
 
         fn hash<T: Hash>(t: &T) -> u64 {
-            let mut s = SipHasher::new();
+            let mut s = DefaultHasher::new();
             t.hash(&mut s);
             s.finish()
         }


### PR DESCRIPTION
SipHasher has been deprecated and the use of DefaultHasher is suggested.

References:

1) https://github.com/rust-lang/rust/pull/36815
2) https://github.com/rust-lang/rust/issues/34767
3) https://doc.rust-lang.org/std/hash/struct.SipHasher.html